### PR TITLE
fix(docs): 修复 API 文档域名显示异常

### DIFF
--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -327,7 +327,7 @@ export default function DocsPage({ origin }: { origin: string }) {
                   <h3 className="text-xs font-bold uppercase tracking-wider text-muted-foreground mb-3">
                     {t("docs.example_request")}
                   </h3>
-                  <CodeBlock>{`curl "https://your-domain.com/api/lookup?query=google.com"`}</CodeBlock>
+                  <CodeBlock>{`curl "https://who.zmh.me/api/lookup?query=google.com"`}</CodeBlock>
                 </div>
 
                 <div>
@@ -433,7 +433,7 @@ export default function DocsPage({ origin }: { origin: string }) {
                   <h3 className="text-xs font-bold uppercase tracking-wider text-muted-foreground mb-3">
                     {t("docs.example_request")}
                   </h3>
-                  <CodeBlock>{`curl "https://your-domain.com/api/og?query=google.com&theme=dark" -o og.png`}</CodeBlock>
+                  <CodeBlock>{`curl "https://who.zmh.me/api/og?query=google.com&theme=dark" -o og.png`}</CodeBlock>
                 </div>
 
                 <div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example API endpoint URLs in documentation with accurate domain references for GET `/api/lookup` and GET `/api/og` endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zmh-program/next-whois/pull/47)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->